### PR TITLE
Implement import wallet functionality

### DIFF
--- a/SplashScreen.py
+++ b/SplashScreen.py
@@ -115,19 +115,17 @@ class SplashScreen(object):
         The user gives the name and password (and private keys if importing) on a prompt, which is passed here.
         :return: Process Object Return Code
         """
-        arguments = [
+        walletd_args = [
             get_wallet_daemon_path(),
             '-w', os.path.join(cur_dir, name + ".wallet"),
             '-p', password,
             '-g'
         ]
         if view_key:
-            arguments.append('--view-key')
-            arguments.append(view_key)
+            walletd_args.extend(['--view-key', view_key])
         if spend_key:
-            arguments.append('--spend-key')
-            arguments.append(spend_key)
-        walletd = Popen(arguments)
+            walletd_args.extend(['--spend-key', spend_key])
+        walletd = Popen(walletd_args)
         return walletd.wait()
 
     def prompt_wallet_dialog(self):


### PR DESCRIPTION
Add another option to the create/open prompt to allow the user to import a wallet using the view and spend keys.
![image](https://user-images.githubusercontent.com/603793/37881188-ed86781a-3048-11e8-8497-c538b9c52075.png)
![image](https://user-images.githubusercontent.com/603793/37881323-24ff3cc6-304b-11e8-883f-a55e148d44d6.png)